### PR TITLE
Fix manifest error and hot reload

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -270,8 +270,8 @@ module.exports = function(webpackEnv) {
               : false,
           },
           cssProcessorPluginOptions: {
-              preset: ['default', { minifyFontValues: { removeQuotes: false } }]
-          }
+            preset: ['default', { minifyFontValues: { removeQuotes: false } }],
+          },
         }),
       ],
       // Automatically split vendor and commons
@@ -661,8 +661,12 @@ module.exports = function(webpackEnv) {
             manifest[file.name] = file.path;
             return manifest;
           }, seed);
-          const entrypointFiles = entrypoints.main.filter(
-            fileName => !fileName.endsWith('.map')
+          const entrypointFiles = Object.entries(entrypoints).reduce(
+            (out, [name, allFiles]) => ({
+              ...out,
+              [name]: allFiles.filter(fileName => !fileName.endsWith('.map')),
+            }),
+            {}
           );
 
           return {


### PR DESCRIPTION
1. In recent versions, CRA now only expects a single entrypoint ("main") but because we add multiple entrypoints via customize-cra and react-app-rewired it throws an error when building the assets manifest file (ref: https://github.com/facebook/create-react-app/blame/0327d8952ad3bb229c26b1a1d793b42755135b84/packages/react-scripts/config/webpack.config.js#L664). So, we tweak the manifest generation to account for our multiple entrypoints.