### PR TITLE
fix: add missing lodash.merge dependency to react-scripts

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -59,6 +59,7 @@
     "jest-environment-jsdom-fourteen": "1.0.1",
     "jest-resolve": "24.9.0",
     "jest-watch-typeahead": "0.4.2",
+    "lodash.merge": "^4.6.2",
     "mini-css-extract-plugin": "0.8.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",
     "pnp-webpack-plugin": "1.5.0",


### PR DESCRIPTION
It's used here
https://github.com/Spendesk/create-react-app/blob/7ceabe7b295539ecaa8ae16fed84113d80b52578/packages/react-scripts/config/webpack.config.js#L15

Which was introduced by https://github.com/Spendesk/create-react-app/commit/7b691fdb5c4d40e3db517c48a18c7984398eb3c2

It works without it because it's probably already installed as dependency of a dependency but we shouldn't assume that