### PR TITLE
turned off node polyfill, which caused issue with csp security rules

### DIFF
--- a/packages/react-scripts/config/webpack.config.js
+++ b/packages/react-scripts/config/webpack.config.js
@@ -676,10 +676,14 @@ module.exports = function(webpackEnv) {
           // The formatter is invoked directly in WebpackDevServerUtils during development
           formatter: isEnvProduction ? typescriptFormatter : undefined,
         }),
+        new webpack.DefinePlugin({
+          global: 'window'		// Placeholder for global used in any node_modules
+       }),
     ].filter(Boolean),
     // Some libraries import Node modules but don't use them in the browser.
     // Tell webpack to provide empty mocks for them so importing them works.
     node: {
+      global: false,
       module: 'empty',
       dgram: 'empty',
       dns: 'mock',


### PR DESCRIPTION
### Description
The polyfill in webpack for the global variable uses `eval`, which conflicts with CSP security rules
https://github.com/webpack/webpack/issues/5627

![Screenshot 2020-10-22 at 16 10 43](https://user-images.githubusercontent.com/27008006/97002347-28b26b00-153a-11eb-85fc-1d061fa4a54e.png)
